### PR TITLE
feat: add sass package importer

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ const browserSync = require('browser-sync');
 const clean = require('gulp-clean');
 const gulpSass = require('gulp-sass')
 const dartSass = require('sass-embedded')
+const packageImporter = require('sass-package-importer');
 const nodemon = require('gulp-nodemon');
 const PluginError = require('plugin-error')
 
@@ -30,7 +31,7 @@ function compileStyles(done) {
   return gulp
     .src(['app/assets/sass/**/*.scss'])
     .pipe(
-      sass()
+      sass({ importers: [packageImporter] })
       .on('error', (error) => {
         done(
           new PluginError('compileCSS', error.messageFormatted, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,8 @@
         "nunjucks": "^3.2.4",
         "path": "^0.12.7",
         "plugin-error": "^2.0.1",
-        "sass-embedded": "1.77.5"
+        "sass-embedded": "1.77.5",
+        "sass-package-importer": "^1.0.0"
       },
       "devDependencies": {
         "eslint": "^8.56.0",
@@ -15938,6 +15939,12 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/sass-package-importer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sass-package-importer/-/sass-package-importer-1.0.0.tgz",
+      "integrity": "sha512-ibWzE3bftWaiXsL7ohWA/7S2kT4hSpXnoHiui4qqkCwCjtomg3gGZpvtP6pzhtA9vxOEBbmKodAAeyM2ItxTEw==",
+      "license": "ISC"
     },
     "node_modules/saxes": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "nunjucks": "^3.2.4",
     "path": "^0.12.7",
     "plugin-error": "^2.0.1",
-    "sass-embedded": "1.77.5"
+    "sass-embedded": "1.77.5",
+    "sass-package-importer": "^1.0.0"
   },
   "devDependencies": {
     "eslint": "^8.56.0",


### PR DESCRIPTION
## Summary
- add sass-package-importer dependency
- configure gulp sass to resolve packages from node_modules

## Testing
- `npm run build`
- `npm test`
- `npm run lint:js` *(fails: Missing trailing comma in app.js, More than 1 blank line not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_689c97cdcfa8833391f619d887391e99