### PR TITLE
Handle ErrorSummary module shape in tests and forms

### DIFF
--- a/app/lib/views/111/components/NHS111.Shared.Frontend/src/js/main.js
+++ b/app/lib/views/111/components/NHS111.Shared.Frontend/src/js/main.js
@@ -13,20 +13,22 @@ import { initInlineSpinners } from "./modules/inline-spinner";
 import { initInterstitialForm } from "./modules/interstitial-form";
 import initLoadingSpinners from "./modules/loading-spinner";
 import { initServiceAuditing } from "./service-auditing";
+import { normaliseErrorSummary } from "./modules/utils/form-helpers";
 
 document.addEventListener("DOMContentLoaded", () => {
+  const initialiseErrorSummary = normaliseErrorSummary(ErrorSummary);
   // Initialise nhsuk-frontend modules
   Button();
   CharacterCount();
   Details();
-  ErrorSummary();
+  initialiseErrorSummary();
 
   // Initialise third party modules
   autosize(document.querySelectorAll("[data-autosize]"));
 
   // Initialise custom modules
   initClickEvents();
-  initFeedback(ErrorSummary);
+  initFeedback(initialiseErrorSummary);
   initLoadingSpinners();
   initInlineSpinners();
   initServiceAuditing();

--- a/app/lib/views/111/components/NHS111.Shared.Frontend/src/js/modules/email-survey.js
+++ b/app/lib/views/111/components/NHS111.Shared.Frontend/src/js/modules/email-survey.js
@@ -8,7 +8,7 @@ export class EmailSurveyForm {
     );
     this.button = this.form.querySelector("[data-email-survey-submit]");
     this.cancelButton = this.form.querySelector("[data-email-survey-cancel]");
-    this.ErrorSummary = ErrorSummary;
+    this.ErrorSummary = formHelpers.normaliseErrorSummary(ErrorSummary);
   }
 
   init() {

--- a/app/lib/views/111/components/NHS111.Shared.Frontend/src/js/modules/email-survey.test.js
+++ b/app/lib/views/111/components/NHS111.Shared.Frontend/src/js/modules/email-survey.test.js
@@ -84,7 +84,9 @@ describe("email survey", () => {
 
       initSurvey(ErrorSummary);
 
-      document.querySelector("form").submit();
+      document
+        .querySelector("form")
+        .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
 
       expect(submitHandlerCalled).toEqual(true);
 

--- a/app/lib/views/111/components/NHS111.Shared.Frontend/src/js/modules/feedback.js
+++ b/app/lib/views/111/components/NHS111.Shared.Frontend/src/js/modules/feedback.js
@@ -8,7 +8,7 @@ export class FeedbackForm {
     this.formSections = this.form.querySelectorAll(
       "[data-feedback-form-section]"
     );
-    this.ErrorSummary = ErrorSummary;
+    this.ErrorSummary = formHelpers.normaliseErrorSummary(ErrorSummary);
   }
 
   init() {

--- a/app/lib/views/111/components/NHS111.Shared.Frontend/src/js/modules/feedback.test.js
+++ b/app/lib/views/111/components/NHS111.Shared.Frontend/src/js/modules/feedback.test.js
@@ -107,7 +107,9 @@ describe("feedback", () => {
 
       initFeedback(ErrorSummary);
 
-      document.querySelector("form").submit();
+      document
+        .querySelector("form")
+        .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
 
       expect(submitHandlerCalled).toEqual(true);
 
@@ -400,7 +402,7 @@ describe("feedback", () => {
       expect(getFeedbackCharacterLimitMock).toHaveBeenCalled();
       expect(formErrorMock).toHaveBeenCalledWith(
         document.querySelector("form"),
-        ErrorSummary,
+        expect.any(Function),
         "feedback-text",
         "Enter your feedback"
       );
@@ -430,7 +432,7 @@ describe("feedback", () => {
       expect(getFeedbackCharacterLimitMock).toHaveBeenCalled();
       expect(formErrorMock).toHaveBeenCalledWith(
         document.querySelector("form"),
-        ErrorSummary,
+        expect.any(Function),
         "feedback-text",
         "Enter your feedback"
       );
@@ -454,7 +456,7 @@ describe("feedback", () => {
       expect(getFeedbackCharacterLimitMock).toHaveBeenCalled();
       expect(formErrorMock).toHaveBeenCalledWith(
         document.querySelector("form"),
-        ErrorSummary,
+        expect.any(Function),
         "feedback-text",
         "Feedback should be fewer than 1200 characters long",
         "Feedback should be fewer than 1200 characters long - you have 1 character too many"

--- a/app/lib/views/111/components/NHS111.Shared.Frontend/src/js/modules/utils/form-helpers.js
+++ b/app/lib/views/111/components/NHS111.Shared.Frontend/src/js/modules/utils/form-helpers.js
@@ -42,6 +42,21 @@ export function trackOriginalAria(form) {
   );
 }
 
+export function normaliseErrorSummary(ErrorSummary) {
+  if (typeof ErrorSummary === "function") {
+    return ErrorSummary;
+  }
+
+  if (
+    ErrorSummary &&
+    typeof ErrorSummary.initErrorSummary === "function"
+  ) {
+    return (...args) => ErrorSummary.initErrorSummary(...args);
+  }
+
+  return () => {};
+}
+
 export function formError(
   form,
   ErrorSummary,
@@ -72,10 +87,19 @@ export function formError(
     previousErrorSummary.remove();
   }
 
+  const initialiseErrorSummary = normaliseErrorSummary(ErrorSummary);
   const errorSummary = template.content;
 
   form.prepend(errorSummary);
-  ErrorSummary();
+  initialiseErrorSummary();
+
+  const errorSummaryElement = form.querySelector(
+    "[data-test-id=\"feedback-error-summary\"]"
+  );
+  if (errorSummaryElement) {
+    errorSummaryElement.setAttribute("tabindex", "-1");
+    errorSummaryElement.focus();
+  }
 
   const field = form.querySelector(`#${fieldId}`);
   const formGroup = field.closest(".nhsuk-form-group");


### PR DESCRIPTION
## Summary
- normalise the ErrorSummary dependency so form helpers can work with either function or module exports and ensure the summary receives focus
- pass the normalised ErrorSummary through the feedback and email survey flows and initialise it once in main.js
- update form submission tests to dispatch submit events instead of calling the unimplemented jsdom submit method and relax expectations around the callback shape

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_690cc9072a588333a15821252a271bed